### PR TITLE
Add name attribute to plugin

### DIFF
--- a/casepropods/family_connect_registration/plugin.py
+++ b/casepropods/family_connect_registration/plugin.py
@@ -11,6 +11,7 @@ class RegistrationPod(Pod):
 
 
 class RegistrationPlugin(PodPlugin):
+    name = 'casepropods.family_connect_registration'
     label = 'family_connect_registration_pod'
     pod_class = RegistrationPod
     config_class = RegistrationPodConfig


### PR DESCRIPTION
This prevents an error caused by having multiple pods with the same name.
