### PR TITLE
Add Travis file

### DIFF
--- a/.travis-casepro-additional-settings.py
+++ b/.travis-casepro-additional-settings.py
@@ -1,0 +1,3 @@
+INSTALLED_APPS += (
+    'casepropods.family_connect_registration.plugin.RegistrationPlugin',
+)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+# This Travis file is way more complex than we'd like. It needs to be quite
+# similar to the praekelt/casepro Travis file because that's where this pod
+# is installed. CasePro isn't served as a Python package which makes this
+# difficult.
+
+sudo: false
+
+language: python
+python:
+  - '2.7'
+  - '3.4.4'
+  - '3.5'
+
+services:
+  - redis-server
+
+addons:
+  - postgresql: '9.3'
+
+before_install:
+  # Clone the latest casepro repo, install the dependencies and setup
+  # the database
+  - git clone https://github.com/praekelt/casepro.git /tmp/casepro
+  - pip install -r /tmp/casepro/pip-freeze.txt
+  - psql -U postgres -c "CREATE USER casepro WITH PASSWORD 'nyaruka';"
+  - psql -U postgres -c "ALTER ROLE casepro WITH SUPERUSER;"
+  - psql -U casepro postgres -c "CREATE DATABASE casepro;"
+  # Append to the CasePro settings file to install this pod as an app
+  - cat $TRAVIS_BUILD_DIR/.travis-casepro-additional-settings.py >> /tmp/casepro/casepro/settings.py.dev
+  - ln -s /tmp/casepro/casepro/settings.py.dev /tmp/casepro/casepro/settings.py
+
+install:
+  - pip install -e $TRAVIS_BUILD_DIR/
+
+script:
+  - python /tmp/casepro/manage.py test -k $TRAVIS_BUILD_DIR/


### PR DESCRIPTION
This Travis file is way more complex than we'd like. It needs to be quite similar to the praekelt/casepro Travis file because that's where this pod is installed. CasePro isn't served as a Python package which makes this difficult.