### PR TITLE
Return earlier if contact.uuid is None

### DIFF
--- a/casepropods/family_connect_registration/plugin.py
+++ b/casepropods/family_connect_registration/plugin.py
@@ -25,6 +25,7 @@ class RegistrationPod(Pod):
         from casepro.cases.models import Case
 
         # Setup
+        content = {"items": []}
         url = self.config.url
         token = self.config.token
         contact_id_fieldname = self.config.contact_id_fieldname
@@ -36,6 +37,9 @@ class RegistrationPod(Pod):
         case_id = params["case_id"]
         case = Case.objects.get(pk=case_id)
 
+        if case.contact.uuid is None:
+            return content
+
         # Get and format registration response
         r = requests.get(url, params={contact_id_fieldname: case.contact.uuid},
                          headers=headers)
@@ -43,7 +47,6 @@ class RegistrationPod(Pod):
         response = r.json()
         results = response["results"]
 
-        content = {"items": []}
         for result in results:
             for obj in mapping:
                 if obj["field"] in result:

--- a/casepropods/family_connect_registration/tests.py
+++ b/casepropods/family_connect_registration/tests.py
@@ -136,3 +136,15 @@ class RegistrationPodTest(BaseCasesTest):
                 "hcw00001-63e2-4acc-9b94-26663b9bc267"},
             {"name": "Receives Messages As", "value": "text"},
         ]})
+
+    @responses.activate
+    def test_no_http_request_if_contact_uuid_is_none(self):
+        contact_no_uuid = self.create_contact(self.unicef, None, "Mother")
+        message = self.create_message(self.unicef, 1234, contact_no_uuid, "Hello")
+        case = Case.get_or_open(
+            self.unicef, self.user1, message, "Summary", self.moh)
+
+        result = self.pod.read_data({'case_id': case.id})
+
+        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(result, {'items': []})


### PR DESCRIPTION
In the case where the contact doesn't have a UUID associated, the pod will make a request to the hub service without any params, which means (I think) it will mistakenly display the first contact's information in the interface.

I suspect it's probably not possible for it to get into the state where a contact doesn't have a UUID but it's probably better to defend against it :)