### PR TITLE
Fix tests for new client

### DIFF
--- a/casepropods/family_connect_registration/tests.py
+++ b/casepropods/family_connect_registration/tests.py
@@ -135,7 +135,7 @@ class RegistrationPodTest(BaseCasesTest):
 
         responses.add(
             responses.GET, self.identity_store_url,
-            json={},
+            json={'details': {}},
             match_querystring=True, content_type="application/json")
 
         result = self.pod.read_data({'case_id': self.case.id})
@@ -166,7 +166,7 @@ class RegistrationPodTest(BaseCasesTest):
 
         responses.add(
             responses.GET, self.identity_store_url,
-            json={},
+            json={'details': {}},
             match_querystring=True, content_type="application/json")
 
         result = self.pod.read_data({'case_id': self.case.id})
@@ -241,7 +241,7 @@ class RegistrationPodTest(BaseCasesTest):
 
         responses.add(
             responses.GET, self.identity_store_url,
-            json={},
+            json={'details': {}},
             match_querystring=True, content_type="application/json")
 
         result = self.pod.read_data({'case_id': self.case.id})
@@ -294,7 +294,7 @@ class RegistrationPodTest(BaseCasesTest):
 
         responses.add(
             responses.GET, self.identity_store_url,
-            json={},
+            json={'details': {}},
             match_querystring=True, content_type="application/json")
 
         result = self.pod.read_data({'case_id': self.case.id})


### PR DESCRIPTION
Currently, with the latest version of the identity store client, it interprets an empty json response `{}` as None, so we need to put something in those empty JSON responses so that dictionary operations don't error.

This is only an issue with our unit tests, and the real API would never return an empty response `{}`