### PR TITLE
Add switch channel action to pod

### DIFF
--- a/casepropods/family_connect_registration/plugin.py
+++ b/casepropods/family_connect_registration/plugin.py
@@ -152,7 +152,7 @@ class RegistrationPod(Pod):
             if data.get('optedout', False):
                 continue
             if data.get('default', False):
-                continue
+                return address
             msisdn = address
         return msisdn
 

--- a/casepropods/family_connect_registration/plugin.py
+++ b/casepropods/family_connect_registration/plugin.py
@@ -1,6 +1,10 @@
 from confmodel import fields
 from casepro.pods import Pod, PodConfig, PodPlugin
 from demands import HTTPServiceError
+try:
+    import itertools.ifilter as filter
+except ImportError:
+    pass
 import re
 import requests
 from seed_services_client import (
@@ -115,7 +119,7 @@ class RegistrationPod(Pod):
         res.raise_for_status()
         res = res.json()
         existing = filter(lambda d: d.get('exists', False), res.values())
-        return bool(existing)
+        return any(existing)
 
     def get_switch_channel_action(self, channel, identity):
         """

--- a/casepropods/family_connect_registration/tests.py
+++ b/casepropods/family_connect_registration/tests.py
@@ -643,3 +643,45 @@ class RegistrationPodTest(BaseCasesTest):
                 "message": "Failed to switch to WhatsApp"
             })
         )
+
+    def test_get_address_from_identity(self):
+        """
+        The get_address_from_identity method should get the correct address
+        from the provided identity
+        """
+        address = self.pod.get_address_from_identity({
+            'details': {
+                'addresses': {
+                    'msisdn': {
+                        '+27820000000': {},
+                    },
+                },
+            },
+        })
+        self.assertEqual(address, '+27820000000')
+
+        # Should skip opted out addresses
+        address = self.pod.get_address_from_identity({
+            'details': {
+                'addresses': {
+                    'msisdn': {
+                        '+27820000000': {'optedout': True},
+                    },
+                },
+            },
+        })
+        self.assertEqual(address, None)
+
+        # Should return default addresses if other addresses are present
+        address = self.pod.get_address_from_identity({
+            'details': {
+                'addresses': {
+                    'msisdn': {
+                        '+27820000000': {},
+                        '+27821111111': {'default': True},
+                        '+27822222222': {},
+                    },
+                },
+            },
+        })
+        self.assertEqual(address, '+27821111111')

--- a/casepropods/family_connect_registration/tests.py
+++ b/casepropods/family_connect_registration/tests.py
@@ -477,17 +477,9 @@ class RegistrationPodTest(BaseCasesTest):
             callback=self.registration_callback_no_matches,
             match_querystring=True, content_type="application/json")
 
-        responses.add(
+        responses.add_callback(
             responses.GET, self.identity_store_url,
-            json={
-                'details': {
-                    'addresses': {
-                        'msisdn': {
-                            '+27820000000': {},
-                        },
-                    },
-                },
-            },
+            callback=self.identity_callback,
             match_querystring=True, content_type="application/json")
 
         responses.add_callback(

--- a/casepropods/family_connect_registration/tests.py
+++ b/casepropods/family_connect_registration/tests.py
@@ -154,7 +154,7 @@ class RegistrationPodTest(BaseCasesTest):
             {"name": "Head of Household ID", "value": "Unknown"},
             {"name": "Operator ID", "value": "Unknown"},
             {"name": "Receives Messages As", "value": "Unknown"},
-        ]})
+        ], 'actions': []})
 
     @responses.activate
     def test_read_data_one_registration(self):
@@ -188,7 +188,7 @@ class RegistrationPodTest(BaseCasesTest):
             {"name": "Operator ID", "value":
                 "hcw00001-63e2-4acc-9b94-26663b9bc267"},
             {"name": "Receives Messages As", "value": "text"},
-        ]})
+        ], 'actions': []})
 
     @responses.activate
     def test_can_get_data_from_identity_store(self):
@@ -225,7 +225,7 @@ class RegistrationPodTest(BaseCasesTest):
         result = self.pod.read_data({'case_id': case.id})
 
         self.assertEqual(len(responses.calls), 0)
-        self.assertEqual(result, {'items': []})
+        self.assertEqual(result, {'items': [], 'actions': []})
 
     @responses.activate
     def test_top_level_results_precendence_over_data(self):


### PR DESCRIPTION
This action will allow the operator to switch the user between WhatsApp and SMS messaging.

This action should only be shown if the user has subscriptions that can be switched, and if their number is registered on the WhatsApp system.