### PR TITLE
Ensure that the switch to sms button shows if no whatsapp

### DIFF
--- a/casepropods/family_connect_registration/plugin.py
+++ b/casepropods/family_connect_registration/plugin.py
@@ -156,7 +156,8 @@ class RegistrationPod(Pod):
             msisdn = address
         return msisdn
 
-    def channel_switch_option_available(self, identity, active_subs):
+    def channel_switch_option_available(
+                self, identity, active_subs, current_channel):
         """
         Returns True if the channel switch option should be shown, else
         returns False.
@@ -164,6 +165,12 @@ class RegistrationPod(Pod):
         if len(active_subs) == 0:
             # If no active subscriptions, then cannot change channel
             return False
+
+        # If they have any WhatsApp subscription, then they should be allowed
+        # to switch back to SMS
+        if current_channel == 'whatsapp':
+            return True
+
         # Check if registered on WhatsApp network
         msisdn = self.get_address_from_identity(identity)
         return self.has_whatsapp_account(msisdn)
@@ -214,8 +221,9 @@ class RegistrationPod(Pod):
         messagesets = self.stage_based_messaging.get_messagesets()
         messagesets = list(messagesets['results'])
 
-        if self.channel_switch_option_available(identity, subscriptions):
-            channel = self.get_current_channel(subscriptions, messagesets)
+        channel = self.get_current_channel(subscriptions, messagesets)
+        if self.channel_switch_option_available(
+                identity, subscriptions, channel):
             actions.append(self.get_switch_channel_action(channel, identity))
 
         return result

--- a/casepropods/family_connect_registration/tests.py
+++ b/casepropods/family_connect_registration/tests.py
@@ -504,7 +504,8 @@ class RegistrationPodTest(BaseCasesTest):
     def test_channel_switch_on_whatsapp(self):
         """
         If they're on the WhatsApp messageset, then they should be given the
-        option to switch to the SMS messageset.
+        option to switch to the SMS messageset, even if they're not registered
+        on WhatsApp
         """
         responses.add_callback(
             responses.GET, self.url,
@@ -528,7 +529,7 @@ class RegistrationPodTest(BaseCasesTest):
 
         responses.add_callback(
             responses.GET, '{}&address=%2B27820000000'.format(self.wassup_url),
-            callback=self.wassup_callback(True),
+            callback=self.wassup_callback(False),
             match_querystring=True, content_type="application/json")
 
         result = self.pod.read_data({'case_id': self.case.id})


### PR DESCRIPTION
Currently, if a mom switched to whatsapp, and they're not registered on whatsapp, and the helpdesk want to switch them back, they cannot, because the button will not show.

This PR fixes this by always showing the "Switch to SMS" button if they have any active whatsapp subscriptions